### PR TITLE
adds option to run quiet or very quiet

### DIFF
--- a/bin/yaml-lint
+++ b/bin/yaml-lint
@@ -21,6 +21,10 @@ OptionParser.new do |opts|
     options[:veryquiet] = q
   end
 
+  opts.on("-n", "--no-check-file-ext", "Do not check the file extension to match known yaml files.") do |n|
+    options[:nocheckfileext] = true
+  end
+
   opts.on_tail("-h", "--help") do |q|
     puts 'yaml-lint is a tool to check the syntax of your YAML files'
     puts 'Usage: yaml-lint <file(s) or folder(s)>'

--- a/bin/yaml-lint
+++ b/bin/yaml-lint
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'yaml'
+require 'optparse'
 
 begin
   require 'yaml-lint'
@@ -9,21 +10,32 @@ rescue LoadError
   require 'yaml-lint'
 end
 
-if ARGV.any? {|arg| arg =~ /^help$|^--help|^-h|^-/} or ARGV.empty?
-  puts 'yaml-lint is a tool to check the syntax of your YAML files'
-  puts 'Usage: yaml-lint <file(s) or folder(s)>'
-  exit 1
-end
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: yaml-lint <file(s) or folder(s)>"
 
-puts "Checking the content of #{ARGV}"
+  opts.on("-q", "--quiet", "Run quiet. Only log failing files.") do |q|
+    options[:quiet] = q
+  end
+  opts.on("-Q", "--very-quiet", "Run more quiet. Return code is the number of failed files.") do |q|
+    options[:veryquiet] = q
+  end
 
-bad_result = false
+  opts.on_tail("-h", "--help") do |q|
+    puts 'yaml-lint is a tool to check the syntax of your YAML files'
+    puts 'Usage: yaml-lint <file(s) or folder(s)>'
+    exit -1
+  end
+end.parse!
+
+puts "Checking the content of #{ARGV}" unless options[:quiet]
+
+failed = 0
 
 ARGV.each do|file|
-  lint = YamlLint.new(file)
-  result = lint.do_lint
-  bad_result = true unless result
+  lint = YamlLint.new(file, options)
+  failed = failed + lint.do_lint
 end
 
-puts 'Done.'
-exit bad_result ? 1 : 0
+puts 'Done.' unless options[:quiet]
+exit failed

--- a/lib/yaml-lint.rb
+++ b/lib/yaml-lint.rb
@@ -9,15 +9,15 @@ module Logging
               :reset  => "\033[0m" }
 
   def info(message)
-    emit(:message => message, :color => :green)
+    emit(:message => message, :color => :green) unless @config[:quiet]
   end
 
   def warn(message)
-    emit(:message => message, :color => :yellow)
+    emit(:message => message, :color => :yellow) unless @config[:veryquiet]
   end
 
   def error(message)
-    emit(:message => message, :color => :red)
+    emit(:message => message, :color => :red) unless @config[:veryquiet]
   end
 
   def emit(opts={})
@@ -33,50 +33,47 @@ end
 class YamlLint
   include Logging
 
-  def initialize(file)
+  def initialize(file, config={})
     @file = file
-    @error = false
+    @config = config
+    @config[:quiet] = true if @config[:veryquiet]
   end
 
   def do_lint
     unless File.exists? @file
       error "File #{@file} does not exist"
-      @error = true
     else
       if File.directory? @file
-        self.parse_directory @file
+        return self.parse_directory @file
       else
-        self.parse_file @file
+        return self.parse_file @file
       end
     end
-    @error ? false : true
   end
 
   def parse_directory(directory)
-    Dir.glob("#{directory}/*").each do |fdir|
+    Dir.glob("#{directory}/*").inject(0) do |mem, fdir|
       if File.directory? fdir
-        self.parse_directory fdir
+        mem + parse_directory(fdir)
       else
-        self.parse_file fdir
+        mem + parse_file(fdir)
       end
     end
-    nil
   end
 
   def parse_file(file)
     unless File.extname(file) =~ /.(yaml|yml)$/
       error "The extension of the file #{file} should be .yaml or .yml"
-      @error = true
-      return
+      return 1
     end
     begin
       YAML.load_file(file)
     rescue Exception => err
       error "File : #{file}, error: #{err}"
-      @error = true
+      return 1
     else
       info "File : #{file}, Syntax OK"
+      return 0
     end
-    nil
   end
 end

--- a/lib/yaml-lint.rb
+++ b/lib/yaml-lint.rb
@@ -37,6 +37,7 @@ class YamlLint
     @file = file
     @config = config
     @config[:quiet] = true if @config[:veryquiet]
+    @config[:nocheckfileext] ||= false
   end
 
   def do_lint
@@ -62,7 +63,7 @@ class YamlLint
   end
 
   def parse_file(file)
-    unless File.extname(file) =~ /.(yaml|yml)$/
+    if (not File.extname(file) =~ /.(yaml|yml)$/) && (not @config[:nocheckfileext])
       error "The extension of the file #{file} should be .yaml or .yml"
       return 1
     end

--- a/spec/fixtures/good.lmay
+++ b/spec/fixtures/good.lmay
@@ -1,0 +1,1 @@
+good.yaml

--- a/spec/fixtures/good.yml
+++ b/spec/fixtures/good.yml
@@ -1,0 +1,1 @@
+good.yaml

--- a/spec/yamllint_spec.rb
+++ b/spec/yamllint_spec.rb
@@ -7,12 +7,37 @@ describe 'YamlLint' do
   describe '.do_lint' do
     it 'accepts a good yaml file' do
       lint = YamlLint.new(FIXTURES_PATH + 'good.yaml')
-      expect(lint.do_lint).to be true
-    end 
-    
+      expect(lint.do_lint).to eq 0
+    end
+
     it 'refuses a bad yaml file' do
       lint = YamlLint.new(FIXTURES_PATH + 'bad.yaml')
-      expect(lint.do_lint).to be false
-    end 
+      expect(lint.do_lint).to eq 1
+    end
+
+    it 'checks both files in a dir' do
+      lint = YamlLint.new(FIXTURES_PATH)
+      expect(lint.do_lint).to eq 1
+    end
+  end
+
+  describe 'the logging' do
+    it 'writes OK and error when not quiet' do
+      lint = YamlLint.new(FIXTURES_PATH)
+      expect { lint.do_lint }.to output(/Syntax OK/).to_stdout
+      expect { lint.do_lint }.to output(/error/).to_stdout
+    end
+
+    it 'does write only errors when quiet' do
+      lint = YamlLint.new(FIXTURES_PATH, {:quiet => true})
+      expect { lint.do_lint }.to_not output(/Syntax OK/).to_stdout
+      expect { lint.do_lint }.to output(/error/).to_stdout
+    end
+
+    it 'does not write anything when very quiet' do
+      lint = YamlLint.new(FIXTURES_PATH, {:veryquiet => true})
+      expect { lint.do_lint }.to_not output(/Syntax OK/).to_stdout
+      expect { lint.do_lint }.to_not output(/error/).to_stdout
+    end
   end
 end

--- a/spec/yamllint_spec.rb
+++ b/spec/yamllint_spec.rb
@@ -17,7 +17,7 @@ describe 'YamlLint' do
 
     it 'checks both files in a dir' do
       lint = YamlLint.new(FIXTURES_PATH)
-      expect(lint.do_lint).to eq 1
+      expect(lint.do_lint).to be > 0
     end
   end
 
@@ -38,6 +38,26 @@ describe 'YamlLint' do
       lint = YamlLint.new(FIXTURES_PATH, {:veryquiet => true})
       expect { lint.do_lint }.to_not output(/Syntax OK/).to_stdout
       expect { lint.do_lint }.to_not output(/error/).to_stdout
+    end
+  end
+
+  describe 'with different file extensions' do
+
+    it 'is okay with known extensions' do
+      lint = YamlLint.new(FIXTURES_PATH + 'good.yaml')
+      expect(lint.do_lint).to eq 0
+      lint = YamlLint.new(FIXTURES_PATH + 'good.yml')
+      expect(lint.do_lint).to eq 0
+    end
+
+    it 'is not okay with an unknown extensions' do
+      lint = YamlLint.new(FIXTURES_PATH + 'good.lmay')
+      expect(lint.do_lint).to eq 1
+    end
+
+    it 'is okay with an unknown extensions when the extension is not checked' do
+      lint = YamlLint.new(FIXTURES_PATH + 'good.lmay', {:nocheckfileext => true})
+      expect(lint.do_lint).to eq 0
     end
   end
 end


### PR DESCRIPTION
With this PR the yaml-lint program will be able to run in quiet-mode (`-q` on the CLI) which will result in only error messages getting logged. Also a very-quiet-mode (`-Q`) can be used to never log any message. In all cases the number of failing files will be used as the return code.