### PR TITLE
removes questionable check for dir == "." or ".."

### DIFF
--- a/lib/yaml-lint.rb
+++ b/lib/yaml-lint.rb
@@ -53,7 +53,6 @@ class YamlLint
   end
 
   def parse_directory(directory)
-    return nil if ['.', '..'].include? directory
     Dir.glob("#{directory}/*").each do |fdir|
       if File.directory? fdir
         self.parse_directory fdir


### PR DESCRIPTION
Am I missing something here? I really do not see a reason why we shouldn't check files from `.` or `..`.

This closes #3 