### PR TITLE
Add option description when using --help

### DIFF
--- a/bin/yaml-lint
+++ b/bin/yaml-lint
@@ -12,7 +12,7 @@ end
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "Usage: yaml-lint <file(s) or folder(s)>"
+  opts.banner = "Usage: yaml-lint [options] <file(s) or folder(s)>"
 
   opts.on("-q", "--quiet", "Run quiet. Only log failing files.") do |q|
     options[:quiet] = q
@@ -27,7 +27,7 @@ OptionParser.new do |opts|
 
   opts.on_tail("-h", "--help") do |q|
     puts 'yaml-lint is a tool to check the syntax of your YAML files'
-    puts 'Usage: yaml-lint <file(s) or folder(s)>'
+    puts opts
     exit -1
   end
 end.parse!


### PR DESCRIPTION
Add option description when using --help，eg:
```bash
$ yaml-lint --help
yaml-lint is a tool to check the syntax of your YAML files
Usage: yaml-lint [options] <file(s) or folder(s)>
    -q, --quiet                      Run quiet. Only log failing files.
    -Q, --very-quiet                 Run more quiet. Return code is the number of failed files.
    -n, --no-check-file-ext          Do not check the file extension to match known yaml files.
    -h, --help
```