### PR TITLE
Fix issue with occasional double forward-slashes in file path log out…

### DIFF
--- a/lib/yaml-lint.rb
+++ b/lib/yaml-lint.rb
@@ -46,7 +46,8 @@ class YamlLint
       return 0
     else
       if File.directory? @file
-        return self.parse_directory @file
+        directory = format_directory(@file)
+        return self.parse_directory directory
       else
         return self.parse_file @file
       end
@@ -81,5 +82,11 @@ class YamlLint
       info "File : #{file}, Syntax OK"
       return 0
     end
+  end
+
+  private
+
+  def format_directory(directory)
+    directory[-1] == '/' ? directory.chop : directory
   end
 end


### PR DESCRIPTION
When using the gem, I noticed that there are issues with double forward slashes in file path log output when running the linter against a directory.

Example output:

```
tash@pocari:~/dev$ yaml-lint -i yaml-lint/
Checking the content of ["yaml-lint/"]
File : yaml-lint//bin/yaml-lint, Ignored
File : yaml-lint//Gemfile, Ignored
File : yaml-lint//Gemfile.lock, Ignored
File : yaml-lint//lib/yaml-lint.rb, Ignored
File : yaml-lint//README.md, Ignored
File : yaml-lint//spec/fixtures/bad.yaml, error: (yaml-lint//spec/fixtures/bad.yaml): mapping values are not allowed in this context at line 3 column 5
File : yaml-lint//spec/fixtures/good.lmay, Ignored
File : yaml-lint//spec/fixtures/good.yaml, Syntax OK
File : yaml-lint//spec/fixtures/good.yml, Syntax OK
File : yaml-lint//spec/spec_helper.rb, Ignored
File : yaml-lint//spec/yamllint_spec.rb, Ignored
File : yaml-lint//yaml-lint.gemspec, Ignored
Done.
```

**I've added a small fix** that strips any trailing forward slashes from directory input. This produces correct output for all possible argument types.

Directory with trailing forward slash:

```
tash@pocari:~/dev/yaml-lint$ bin/yaml-lint ../yaml-lint/
Checking the content of ["../yaml-lint/"]
The extension of the file ../yaml-lint/bin/yaml-lint should be .yaml or .yml
The extension of the file ../yaml-lint/Gemfile should be .yaml or .yml
The extension of the file ../yaml-lint/lib/yaml-lint.rb should be .yaml or .yml
The extension of the file ../yaml-lint/README.md should be .yaml or .yml
File : ../yaml-lint/spec/fixtures/bad.yaml, error: (../yaml-lint/spec/fixtures/bad.yaml): mapping values are not allowed in this context at line 3 column 5
The extension of the file ../yaml-lint/spec/fixtures/good.lmay should be .yaml or .yml
File : ../yaml-lint/spec/fixtures/good.yaml, Syntax OK
File : ../yaml-lint/spec/fixtures/good.yml, Syntax OK
The extension of the file ../yaml-lint/spec/spec_helper.rb should be .yaml or .yml
The extension of the file ../yaml-lint/spec/yamllint_spec.rb should be .yaml or .yml
The extension of the file ../yaml-lint/yaml-lint.gemspec should be .yaml or .yml
Done.
```

Directory without trailing forward slash:

```
tash@pocari:~/dev/yaml-lint$ bin/yaml-lint -i ../yaml-lint
Checking the content of ["../yaml-lint"]
File : ../yaml-lint/bin/yaml-lint, Ignored
File : ../yaml-lint/Gemfile, Ignored
File : ../yaml-lint/lib/yaml-lint.rb, Ignored
File : ../yaml-lint/README.md, Ignored
File : ../yaml-lint/spec/fixtures/bad.yaml, error: (../yaml-lint/spec/fixtures/bad.yaml): mapping values are not allowed in this context at line 3 column 5
File : ../yaml-lint/spec/fixtures/good.lmay, Ignored
File : ../yaml-lint/spec/fixtures/good.yaml, Syntax OK
File : ../yaml-lint/spec/fixtures/good.yml, Syntax OK
File : ../yaml-lint/spec/spec_helper.rb, Ignored
File : ../yaml-lint/spec/yamllint_spec.rb, Ignored
File : ../yaml-lint/yaml-lint.gemspec, Ignored
Done.
```

File:

```
tash@pocari:~/dev/yaml-lint$ bin/yaml-lint -i ../yaml-lint/spec/fixtures/good.yml 
Checking the content of ["../yaml-lint/spec/fixtures/good.yml"]
File : ../yaml-lint/spec/fixtures/good.yml, Syntax OK
Done.
```