### PR TITLE
Add the ability to exclude file and folders from the search

### DIFF
--- a/bin/yaml-lint
+++ b/bin/yaml-lint
@@ -29,6 +29,10 @@ OptionParser.new do |opts|
     options[:ignorenoyaml] = true
   end
 
+  opts.on("-e x,y,z", "--exclude x,y,z", Array, "Coma-separated list of files or folders to exclude.") do |n|
+    options[:exclude] = n
+  end
+
   opts.on_tail("-h", "--help") do |q|
     puts 'yaml-lint is a tool to check the syntax of your YAML files'
     puts opts

--- a/lib/yaml-lint.rb
+++ b/lib/yaml-lint.rb
@@ -56,6 +56,7 @@ class YamlLint
 
   def parse_directory(directory)
     Dir.glob("#{directory}/*").inject(0) do |mem, fdir|
+      next mem if (Array(@config[:exclude])).include? File.basename(fdir)
       if File.directory? fdir
         mem + parse_directory(fdir)
       else


### PR DESCRIPTION
It would be neat to be able to support files and folders exclusion.
That is what this PR brings.

Examples:

No exclusion:
```
$ yaml-lint -i .
Checking the content of ["."]
File : ./spec/spec_helper.rb, Ignored
File : ./spec/yamllint_spec.rb, Ignored
File : ./spec/fixtures/good.yml, Syntax OK
File : ./spec/fixtures/good.lmay, Ignored
File : ./spec/fixtures/good.yaml, Syntax OK
File : ./spec/fixtures/bad.yaml, error: (./spec/fixtures/bad.yaml): mapping values are not allowed in this context at line 3 column 5
File : ./yaml-lint.gemspec, Ignored
File : ./lib/yaml-lint.rb, Ignored
File : ./bin/yaml-lint, Ignored
File : ./Gemfile, Ignored
File : ./README.md, Ignored
Done.
```

Multiple folders exclusion:
```
$ yaml-lint -i --exclude spec,lib .
Checking the content of ["."]
File : ./yaml-lint.gemspec, Ignored
File : ./bin/yaml-lint, Ignored
File : ./Gemfile, Ignored
File : ./README.md, Ignored
Done.
```

A file:
```
$ yaml-lint -i --exclude bad.yaml .
Checking the content of ["."]
File : ./spec/spec_helper.rb, Ignored
File : ./spec/yamllint_spec.rb, Ignored
File : ./spec/fixtures/good.yml, Syntax OK
File : ./spec/fixtures/good.lmay, Ignored
File : ./spec/fixtures/good.yaml, Syntax OK
File : ./yaml-lint.gemspec, Ignored
File : ./lib/yaml-lint.rb, Ignored
File : ./bin/yaml-lint, Ignored
File : ./Gemfile, Ignored
File : ./README.md, Ignored
Done.
```