### PR TITLE
use unsafe_load in yaml-lint

### DIFF
--- a/lib/yaml-lint.rb
+++ b/lib/yaml-lint.rb
@@ -75,7 +75,7 @@ class YamlLint
       return 1
     end
     begin
-      YAML.load_file(file)
+      YAML.unsafe_load(file)
     rescue Exception => err
       error "File : #{file}, error: #{err}"
       return 1


### PR DESCRIPTION
Starting with psych 4.0 if yaml files have aliases they will break
This also addresses an error with loading of things that look like a Time