### PR TITLE
File.exists? throws error in latest ruby

### DIFF
--- a/lib/yaml-lint.rb
+++ b/lib/yaml-lint.rb
@@ -41,7 +41,7 @@ class YamlLint
   end
 
   def do_lint
-    unless File.exists? @file
+    unless File.exist? @file
       error "File #{@file} does not exist"
       return 0
     else


### PR DESCRIPTION
File.exists? has been deprecated for a while and now in the latest ruby versions it throws an error.