### PR TITLE
Make the yaml load work for for both psych 4 and earlier versions

### DIFF
--- a/lib/yaml-lint.rb
+++ b/lib/yaml-lint.rb
@@ -75,7 +75,7 @@ class YamlLint
       return 1
     end
     begin
-      YAML.unsafe_load(file)
+      ::YAML.respond_to?(:unsafe_load) ? ::YAML.unsafe_load(file) : ::YAML.load_file(file)
     rescue Exception => err
       error "File : #{file}, error: #{err}"
       return 1


### PR DESCRIPTION
#21 added the use of unsafe_load which is only available starting psych4 but some users still run earlier version of psych so making the change retro-compatible.

Closes: #24 